### PR TITLE
Restaurant Details: remove add button

### DIFF
--- a/topicApp/src/app/modals/restaurant-details/restaurant-details.component.html
+++ b/topicApp/src/app/modals/restaurant-details/restaurant-details.component.html
@@ -1,7 +1,6 @@
 <ion-header translucent>
   <ion-toolbar>
     <ion-buttons slot="end">
-      <ion-button fill="clear" color="primary"><ion-icon name="add-circle-outline"></ion-icon></ion-button>
       <ion-button fill="clear" color="primary"
                   (click)="shareRestaurant()"><ion-icon name="share-outline"></ion-icon>
       </ion-button>


### PR DESCRIPTION
This button will be removed for now.

Adding a restaurant to a list/guide directly from within the restaurant detail modal will be saved for the v2.0 of the app, due to time constraints.